### PR TITLE
fix README jspm installation package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A cookies plugin for Aurelia.
 
 ## Installation
 ``` shell
-jspm install npm:aurelia-cookie
+jspm install npm:aurelia-cookies
 ```
 
 or


### PR DESCRIPTION
The README for jspm install using wrong package name
